### PR TITLE
Feat(NavIconButton): add routing  wrapper component for Icons on navbar

### DIFF
--- a/__tests__/NavIconButton.test.tsx
+++ b/__tests__/NavIconButton.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import ArchiveIcon from '../components/ArchiveIcon';
+import { NavIconButton } from '../components/NavIconButton'; // 컴포넌트는 나중에 만들 것
+
+// next/navigation의 useRouter를 모킹
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('NavIconButton', () => {
+  const pushMock = jest.fn();
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push: pushMock });
+    pushMock.mockClear();
+  });
+
+  it('should render a button with an Archive icon', () => {
+    render(<NavIconButton to="/archive" icon={<ArchiveIcon />} ariaLabel="go-to-archive" />);
+    const button = screen.getByRole('button', { name: 'go-to-archive' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should call router.push with correct path(Archive) when clicked', () => {
+    render(<NavIconButton to="/archive" icon={<ArchiveIcon />} ariaLabel="archive" />);
+    const button = screen.getByRole('button', { name: 'archive' });
+    fireEvent.click(button);
+    expect(pushMock).toHaveBeenCalledWith('/archive');
+  });
+});

--- a/__tests__/NavIconButton.test.tsx
+++ b/__tests__/NavIconButton.test.tsx
@@ -2,31 +2,38 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import ArchiveIcon from '../components/ArchiveIcon';
+import UserIcon from '../components/UserIcon';
+
 import { NavIconButton } from '../components/NavIconButton'; // 컴포넌트는 나중에 만들 것
 
 // next/navigation의 useRouter를 모킹
 jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
+    useRouter: jest.fn(),
 }));
 
 describe('NavIconButton', () => {
-  const pushMock = jest.fn();
+    const pushMock = jest.fn();
 
-  beforeEach(() => {
-    (useRouter as jest.Mock).mockReturnValue({ push: pushMock });
-    pushMock.mockClear();
-  });
+    beforeEach(() => {
+        (useRouter as jest.Mock).mockReturnValue({ push: pushMock });
+        pushMock.mockClear();
+    });
 
-  it('should render a button with an Archive icon', () => {
-    render(<NavIconButton to="/archive" icon={<ArchiveIcon />} ariaLabel="go-to-archive" />);
-    const button = screen.getByRole('button', { name: 'go-to-archive' });
-    expect(button).toBeInTheDocument();
-  });
+    describe.each([
+        { label: 'archive', path: '/archive', icon: <ArchiveIcon /> },
+        { label: 'user', path: '/user', icon: <UserIcon /> },
+    ])('NavIconButton for $label', ({ label, path, icon }) => {
+        it(`renders ${label} button`, () => {
+            render(<NavIconButton to={path} icon={icon} ariaLabel={label} />);
+            const button = screen.getByRole('button', { name: label });
+            expect(button).toBeInTheDocument();
+        });
 
-  it('should call router.push with correct path(Archive) when clicked', () => {
-    render(<NavIconButton to="/archive" icon={<ArchiveIcon />} ariaLabel="archive" />);
-    const button = screen.getByRole('button', { name: 'archive' });
-    fireEvent.click(button);
-    expect(pushMock).toHaveBeenCalledWith('/archive');
-  });
+        it(`navigates to ${path} when clicked`, () => {
+            render(<NavIconButton to={path} icon={icon} ariaLabel={label} />);
+            const button = screen.getByRole('button', { name: label });
+            fireEvent.click(button);
+            expect(pushMock).toHaveBeenCalledWith(path);
+        });
+    });
 });

--- a/components/NavIconButton.tsx
+++ b/components/NavIconButton.tsx
@@ -1,0 +1,25 @@
+// components/NavIconButton.tsx
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+
+type NavIconButtonProps = {
+  to: string;
+  icon: React.ReactNode;
+  ariaLabel: string;
+};
+
+export const NavIconButton = ({ to, icon, ariaLabel }: NavIconButtonProps) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(to);
+  };
+
+  return (
+    <button onClick={handleClick} aria-label={ariaLabel}>
+      {icon}
+    </button>
+  );
+};


### PR DESCRIPTION
# 📌 Pull Request

## ✨ Summary
add routing wrapper component for Icons on navbar

## ✅ Type of Change
Check all that apply:
- [ ] Release: Merge dev into main
- [x] feat: Add new feature
- [ ] fix: Bug fix
- [ ] refactor: Refactor code (no functional changes)
- [ ] docs: Documentation update (e.g., README)
- [ ] chore: Other changes (e.g., configs, dependencies)
- [x] test: Add or update tests
- [ ] style: Code style changes (formatting, whitespace, etc.)
- [ ] ci: CI/CD configuration changes
- [ ] hotfix: Critical fix

## 📌 Details
- add NavIconButton component that can route icons to User and Archive pages
- it takes { to, icon, aria-label } as props

## 🧪 Test Plan
- rendering tests for both icons. it should be rendered correctly. 
- routing tests for both icons. it should be directed to corresponding pages.
